### PR TITLE
Updating node version that should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following will be addressed:
 
 ## Environment
 When developing client code, you will need to following tools:
- - Node v8.11.3 (LTS version) and included NPM version
+ - Node version >=10 (LTS version) and included NPM version
  - Yarn v1.10.3 or greater
 
 The project is built using [lerna](https://lerna.js.org/) to manage the monorepo and [yarn](https://yarnpkg.com/) as the npm client.


### PR DESCRIPTION
I've got the error when setting up the environment:
error conventional-changelog-angular@5.0.12: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.11.3"
error Found incompatible module

Now I'm using v14.16.1 without problems

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
